### PR TITLE
direct users to the starting guide à seapath-architecture

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -62,3 +62,7 @@ Interested in contributing? Please read carefully the [CONTRIBUTING guidelines](
 
 # Governance
 SEAPATH is a project hosted by the [LF Energy Foundation](https://lfenergy.org). This project's techincal charter is located in [[SEAPATH] Technical Charter v2 - APPROVED 2021-01-07.pdf](https://github.com/seapath/contributing/blob/master/%5BSEAPATH%5D%20Technical%20Charter%20v2%20-%20APPROVED%202021-01-07.pdf) and has established it's own processes for managing day-to-day processes in the project at [Project Governance](https://github.com/seapath/contributing/blob/master/CONTRIBUTING.md#project-governance).
+
+# How to start
+
+Please take a look at the [README file in the seapath-architecture repo](https://github.com/seapath/seapath-architecture/blob/main/README.md) to get started.


### PR DESCRIPTION
We've had users mentionning that nowhere in the main project page is indicated "where to start".
Such a page exist, in the seapath-architecture repo. This change is just to mention this starting place in the main project page.