### PR TITLE
Add ci weekly debian

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,6 +10,7 @@
 
 [![ShellCheck on build_debian_iso](https://github.com/seapath/build_debian_iso/actions/workflows/shellcheck-weekly.yml/badge.svg)](https://github.com/seapath/build_debian_iso/actions/workflows/shellcheck-weekly.yml)
 [![Ansible-lint on Ansible repository](https://github.com/seapath/ansible/actions/workflows/ansible-lint-debian-weekly.yml/badge.svg)](https://github.com/seapath/ansible/actions/workflows/ansible-lint-debian-weekly.yml )
+[![Complete CI on Debian Ansible repository](https://github.com/seapath/ansible/actions/workflows/ci-debian-weekly.yml/badge.svg)](https://github.com/seapath/ansible/actions/workflows/ci-debian-weekly.yml)
 
 ## Mission
 


### PR DESCRIPTION
This badge is for the complete CI on the Debian Ansible repository. It will be used to show the status of the CI on the README file.