### PR TITLE
profile/README.md: add installer link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -66,14 +66,12 @@ Virtualization is seen as a key innovation in order to fulfill these needs.
 
 ## Start with SEAPATH
 
-The wiki section [Starting with SEAPATH](https://lf-energy.atlassian.net/wiki/spaces/SEAP/pages/426377387/Starting+with+SEAPATH?atlOrigin=eyJpIjoiMTNhNjk2OTJlNjAzNDYzYzk2Yjk3ZTZmNzI4YWEyZWIiLCJwIjoiYyJ9) describes SEAPATH prerequisites and provide a step-by-step guide for beginners.
+The wiki section [Getting Started](https://lf-energy.atlassian.net/wiki/spaces/SEAP/pages/426377387/Starting+with+SEAPATH?atlOrigin=eyJpIjoiMTNhNjk2OTJlNjAzNDYzYzk2Yjk3ZTZmNzI4YWEyZWIiLCJwIjoiYyJ9) describes SEAPATH prerequisites and provide a step-by-step guide for beginners.
 
 Below is a quick overview of the installation steps of SEAPATH and a link to relevant pages or repository.
-- First, SEAPATH comes with two main distributions, Yocto and Debian. Choose your prefferred version by reading the wiki page [SEAPATH-Debian or SEAPATH-Yocto](https://lf-energy.atlassian.net/wiki/x/7I7lAQ).
-- Then, source your hardware following the wiki section [SEAPATH prerequisites](https://lf-energy.atlassian.net/wiki/spaces/SEAP/pages/421527633/SEAPATH+prerequisites?atlOrigin=eyJpIjoiYjU0N2RkNGRiZDM0NGQxYmJhYjBhN2M3ZTQ1NzMyNDkiLCJwIjoiYyJ9).
-- Build your ISO file(s) using
-    - [yocto_bsp](https://github.com/seapath/yocto-bsp) for Yocto
-    - [build_debian_iso](https://github.com/seapath/build_debian_iso) for Debian
+- First, SEAPATH comes with two main distributions, Yocto and Debian. Choose your preferred version by reading the wiki page [SEAPATH-Debian or SEAPATH-Yocto](https://lf-energy.atlassian.net/wiki/x/7I7lAQ).
+- Then, source your hardware following the wiki section [Prerequisites](https://lf-energy.atlassian.net/wiki/spaces/SEAP/pages/421527633/SEAPATH+prerequisites?atlOrigin=eyJpIjoiYjU0N2RkNGRiZDM0NGQxYmJhYjBhN2M3ZTQ1NzMyNDkiLCJwIjoiYyJ9).
+- Install SEAPATH using the [installer](https://lf-energy.atlassian.net/wiki/spaces/SEAP/pages/537722925/Install+SEAPATH?atlOrigin=eyJpIjoiNTllM2YyYzM0OGRhNDMzZGJhNjQxYTcyZmQ4NGY4MWIiLCJwIjoiYyJ9)
 - If you go for a cluster configuration, wire your machine following [Cluster machine wiring](https://lf-energy.atlassian.net/wiki/spaces/SEAP/pages/427622474/Cluster+setup+and+deployment#Machine-wiring).
 - Finally, configure your machines using the [Ansible](https://github.com/seapath/ansible) repository.
 


### PR DESCRIPTION
Add link to the new seapath-installer wiki page, instead of building and flashing the images manually.

Also correct some wiki page names.