### PR TITLE
governance: add COMMITTERS.md file

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,24 @@
+# COMMITTERS
+
+This file lists the committers for the SEAPATH project and their repository assignments.
+A committer is responsible for reviewing and merging pull requests in their assigned repositories.
+For the process to become a committer, see [seapath_governance.md](seapath_governance.md).
+
+## Repository assignments
+
+### build_debian_iso
+
+- Florent Carli
+
+### Yocto repositories (meta-seapath, meta-seapath-qcom, yocto-bsp, repo-manifest)
+
+- Eloi Bail
+- Mathieu Dupré
+- Erwann Roussy
+
+### Other repositories
+
+- Eloi Bail
+- Florent Carli
+- Mathieu Dupré
+- Erwann Roussy

--- a/key_roles.md
+++ b/key_roles.md
@@ -1,6 +1,9 @@
 # Committers:
-Florent Carli: principal committer for the debian branch.<br>
-Mathieu Dupré: principal committer for the yocto branch.
+Florent Carli: principal committer for the build_debian_iso repository.<br>
+Mathieu Dupré: principal committer for the Yocto repositories.<br>
+Erwann Roussy: committer for the Yocto repositories.
+
+See [COMMITTERS](COMMITTERS.md) for the full per-repository assignment.
 
 # Lead:
 Eloi Bail, Responsible for the overall project health.


### PR DESCRIPTION
Add a COMMITTERS.md file that maps each committer to their assigned repositories:
- build_debian_iso: Florent Carli
- Yocto repositories (meta-seapath, meta-seapath-qcom, yocto-bsp, repo-manifest): Eloi Bail, Mathieu Dupré, Erwann Roussy
- Other repositories: Eloi Bail, Florent Carli, Mathieu Dupré, Erwann Roussy

Update key_roles.md accordingly: add Erwann Roussy as committer for the Yocto repositories, refine Florent Carli's scope to build_debian_iso, and add a reference to the new COMMITTERS.md file.