### PR TITLE
fix Code of Conduct broken link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-This project applies the [LF Energy Code of Conduct](https://wiki.lfenergy.org/display/HOME/Code+of+Conduct). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project's Technical Steering Committee [SEAPATH-tsc@lists.lfenergy.org](mailto:SEAPATH-TSC@lists.lfenergy.org).
+This project applies the [LF Project, LLC](https://lfprojects.org/policies/code-of-conduct/). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project's Technical Steering Committee [SEAPATH-tsc@lists.lfenergy.org](mailto:SEAPATH-TSC@lists.lfenergy.org).


### PR DESCRIPTION
The previous link to the LF Energy Code of Conduct was broken. This commit updates the link to point to the correct LF Project, LLC Code of Conduct page.

This is the default Code of Conduct for LF Projects, according https://tac.lfenergy.org/best_practices/repo.html#code_of_conduct